### PR TITLE
fix: Redirect user to home page after swap

### DIFF
--- a/app/(modals)/swap.tsx
+++ b/app/(modals)/swap.tsx
@@ -691,9 +691,10 @@ export default function SwapScreen() {
     setInsufficientBalance(false);
     setQuoteError(null);
     setTxSignature('');
-    setHasSetDefaultToken(false); // Reset the default token flag
-    // Navigate back immediately, portfolio refresh continues in background
-    router.back();
+    setHasSetDefaultToken(false);
+
+    // Navigate back home immediately, portfolio refresh continues in background
+    router.push('/');
   }, []);
 
   return (


### PR DESCRIPTION
Implemented redirecting users directly to the home page after they execute a swap, rather than back to where they came from. 